### PR TITLE
Update default branch to version 4

### DIFF
--- a/google-cloud-platform/variables.tf
+++ b/google-cloud-platform/variables.tf
@@ -39,7 +39,7 @@ variable "management_image" {
 }
 
 variable "ansible_branch" {
-  default = "3"
+  default = "4"
 }
 
 variable "private_key_path" {

--- a/oracle-cloud-infrastructure/variables.tf
+++ b/oracle-cloud-infrastructure/variables.tf
@@ -58,5 +58,5 @@ variable "ClusterNameTag" {
 }
 
 variable "ansible_branch" {
-  default = "3"
+  default = "4"
 }


### PR DESCRIPTION
The `4` branch of citc-ansible contains Slurm 19.05. This is a breaking change and so required a new version.