### PR TITLE
Fix some warnings from newer terraform

### DIFF
--- a/google/compute.tf
+++ b/google/compute.tf
@@ -28,7 +28,7 @@ resource "google_compute_instance" "mgmt" {
   # Ignore changes to the disk image, as if a family is specified it != the image name on the instance, and continually
   # rebuild when terraform is reapplied
   lifecycle {
-    ignore_changes = ["boot_disk[0].initialize_params[0].image"]
+    ignore_changes = [boot_disk[0].initialize_params[0].image]
   }
 
   # ssh connection information for provisioning

--- a/oracle/compute.tf
+++ b/oracle/compute.tf
@@ -139,7 +139,7 @@ provisioner "remote-exec" {
 
   connection {
     timeout     = "15m"
-    host        = oci_core_instance.ClusterManagement.public_ip
+    host        = self.public_ip
     user        = "opc"
     private_key = file(var.private_key_path)
     agent       = false


### PR DESCRIPTION
The warnings were "Quoted references are deprecated" for the google one and "External references from destroy provisioners are deprecated" for oracle

All three cloud services (aws, google, oracle) will still need a fix to safely refer to the SSH private key at destroy time.

(See #55)